### PR TITLE
Remove types defined in toolkit

### DIFF
--- a/src/types/pkg.ts
+++ b/src/types/pkg.ts
@@ -87,17 +87,6 @@ interface DistributedFile {
  * APM version
  */
 
-export interface ApmVersionRaw {
-  version: string;
-  contentUri: string;
-}
-
-export interface ApmRepoVersionReturn {
-  semanticVersion: number[]; // uint16[3]
-  contractAddress: string; // address
-  contentURI: string; // bytes
-}
-
 export interface PackageRequest {
   name: string;
   ver: string;


### PR DESCRIPTION
These types are already defined in the toolkit and, as they should only be used there, they should not be included in this repository