### PR TITLE
Delete service==dnp comparison

### DIFF
--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -41,13 +41,13 @@ export const getLegacyImagePath = (name: string, version: string): string =>
  * @returns Container domain in the format <service-name>.<dappnode-package-name> if service-name is not empty and different from dappnode-package-name, otherwise returns dappnode-package-name
  */
 export const getContainerDomain = ({
-  dnpName,
   serviceName,
+  dnpName,
 }: {
   serviceName?: string;
   dnpName: string;
 }): string => {
-  return (!serviceName || serviceName === dnpName) ? dnpName : `${serviceName}.${dnpName}`;
+  return serviceName ? `${serviceName}.${dnpName}` : dnpName;
 };
 
 /**

--- a/test/docker.utils.test.ts
+++ b/test/docker.utils.test.ts
@@ -47,6 +47,7 @@ describe("Utils > getImageTag", function () {
       serviceName: "test",
       version: "1.0.0",
     });
-    expect(result).to.equal("test:1.0.0");
+    // we no longer skip "serviceName" if it is equal to "dnpName"
+    expect(result).to.equal("test.test:1.0.0");
   });
 });


### PR DESCRIPTION
if serviceName == dnpName, we will still return `serviceName.dnpName` as the domain, instead of returning only `dnpName`

This is backwards compatible with the packages affected by these changes, which were mono-services with `serviceName == dnpName`. This is because mono-services are always `isMain == true` packages. In main packages, the domain `dnpName` is already added by default