### PR TITLE
Add getJsonRpcApiFromDnpName

### DIFF
--- a/src/types/stakers.ts
+++ b/src/types/stakers.ts
@@ -105,6 +105,7 @@ export type ConsensusClient = (typeof consensusClients)[number];
 export const consensusClients = Object.freeze([
   ...consensusClientsMainnet,
   ...consensusClientsPrater,
+  ...consensusClientsHolesky,
   ...consensusClientsGnosis,
   ...consensusClientsLukso,
 ] as const);
@@ -113,6 +114,7 @@ export type ExecutionClient = (typeof executionClients)[number];
 export const executionClients = Object.freeze([
   ...executionClientsMainnet,
   ...executionClientsPrater,
+  ...executionClientsHolesky,
   ...executionClientsGnosis,
   ...executionClientsLukso,
 ] as const);
@@ -121,6 +123,7 @@ export type Signer = (typeof signers)[number];
 export const signers = Object.freeze([
   signerMainnet,
   signerPrater,
+  signerHolesky,
   signerGnosis,
   signerLukso,
 ] as const);

--- a/src/types/stakers.ts
+++ b/src/types/stakers.ts
@@ -100,6 +100,38 @@ export const executionClientsLukso = Object.freeze([
 export type SignerLukso = "web3signer-lukso.dnp.dappnode.eth";
 export const signerLukso: SignerLukso = "web3signer-lukso.dnp.dappnode.eth";
 
+// COMMON
+export type ConsensusClient = (typeof consensusClients)[number];
+export const consensusClients = Object.freeze([
+  ...consensusClientsMainnet,
+  ...consensusClientsPrater,
+  ...consensusClientsGnosis,
+  ...consensusClientsLukso,
+] as const);
+
+export type ExecutionClient = (typeof executionClients)[number];
+export const executionClients = Object.freeze([
+  ...executionClientsMainnet,
+  ...executionClientsPrater,
+  ...executionClientsGnosis,
+  ...executionClientsLukso,
+] as const);
+
+export type Signer = (typeof signers)[number];
+export const signers = Object.freeze([
+  signerMainnet,
+  signerPrater,
+  signerGnosis,
+  signerLukso,
+] as const);
+
+export type MevBoost = (typeof mevBoosts)[number];
+export const mevBoosts = Object.freeze([
+  mevBoostMainnet,
+  mevBoostPrater,
+  //mevBoostGnosis,
+] as const);
+
 // STAKERS
 export const stakerPkgs = Object.freeze([
   ...executionClientsMainnet,

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -10,3 +10,17 @@ export function isEnsDomain(ensDomain: string): boolean {
 
   return regex.test(ensDomain);
 }
+
+/**
+ * Checks if a domain name is a valid DNP name.
+ * @param dnpName - The domain name to check.
+ * @returns  - True if the domain name is valid, false otherwise.
+ */
+export function isValidDnpName(dnpName: string): boolean {
+  // Regular expression to check for a valid DNP name.
+  // It should have only one subdomain before `.dnp.dappnode.eth` or `.public.dappnode.eth`.
+  const regex = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.(dnp|public)\.dappnode\.eth$/i;
+
+  return regex.test(dnpName);
+}
+

--- a/src/utils/stakers.ts
+++ b/src/utils/stakers.ts
@@ -204,3 +204,31 @@ export function getUrlFromDnpName(): {
     consensusClientLuksoUrl,
   };
 }
+
+export function getJsonRpcApiFromDnpName(dnpName: string): string {
+  const [client, network, , tld] = dnpName.split('.');
+
+  if (tld !== 'eth') throw new Error("Invalid DNP name format.");
+
+  const base = 'dappnode';
+  const executionPort = '8545';
+  const consensusPort = '3500';
+  const nimbusPort = '4500';
+
+  let subdomain = client;
+  let port = executionPort;
+
+  if (['prysm', 'lighthouse', 'teku', 'lodestar'].some(prefix => client.startsWith(prefix))) {
+    subdomain = `beacon-chain.${client}`;
+    port = consensusPort;
+  } else if (client.startsWith('nimbus')) {
+    subdomain = `beacon-validator.${client}`;
+    port = nimbusPort;
+  }
+
+  if (network !== 'dnp') {
+    subdomain = `${subdomain}.${network}`;
+  }
+
+  return `http://${subdomain}.${base}:${port}`;
+}

--- a/test/stakers.utils.test.ts
+++ b/test/stakers.utils.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { getJsonRpcApiFromDnpName } from "../src/utils/index.js";
+
+describe('DNP Name to URL Conversion', function () {
+    const testCases = [
+        // Mainnet Execution Clients
+        { dnpName: "geth.dnp.dappnode.eth", expectedUrl: "http://geth.dappnode:8545" },
+        { dnpName: "besu.public.dappnode.eth", expectedUrl: "http://besu.public.dappnode:8545" },
+        { dnpName: "nethermind.public.dappnode.eth", expectedUrl: "http://nethermind.public.dappnode:8545" },
+        { dnpName: "erigon.dnp.dappnode.eth", expectedUrl: "http://erigon.dappnode:8545" },
+
+        // Mainnet Consensus Clients
+        { dnpName: "prysm.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.prysm.dappnode:3500" },
+        { dnpName: "lighthouse.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lighthouse.dappnode:3500" },
+        { dnpName: "teku.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.teku.dappnode:3500" },
+        { dnpName: "nimbus.dnp.dappnode.eth", expectedUrl: "http://beacon-validator.nimbus.dappnode:4500" },
+        { dnpName: "lodestar.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lodestar.dappnode:3500" },
+
+        // Prater Testnet Execution Clients
+        { dnpName: "goerli-geth.dnp.dappnode.eth", expectedUrl: "http://goerli-geth.dappnode:8545" },
+        { dnpName: "goerli-besu.dnp.dappnode.eth", expectedUrl: "http://goerli-besu.dappnode:8545" },
+        { dnpName: "goerli-nethermind.dnp.dappnode.eth", expectedUrl: "http://goerli-nethermind.dappnode:8545" },
+        { dnpName: "goerli-erigon.dnp.dappnode.eth", expectedUrl: "http://goerli-erigon.dappnode:8545" },
+
+        // Prater Testnet Consensus Clients
+        { dnpName: "prysm-prater.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.prysm-prater.dappnode:3500" },
+        { dnpName: "lighthouse-prater.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lighthouse-prater.dappnode:3500" },
+        { dnpName: "teku-prater.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.teku-prater.dappnode:3500" },
+        { dnpName: "nimbus-prater.dnp.dappnode.eth", expectedUrl: "http://beacon-validator.nimbus-prater.dappnode:4500" },
+        { dnpName: "lodestar-prater.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lodestar-prater.dappnode:3500" },
+
+        // Gnosis Chain Execution Clients
+        { dnpName: "nethermind-xdai.dnp.dappnode.eth", expectedUrl: "http://nethermind-xdai.dappnode:8545" },
+
+        // Gnosis Chain Consensus Clients
+        { dnpName: "lighthouse-gnosis.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lighthouse-gnosis.dappnode:3500" },
+        { dnpName: "teku-gnosis.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.teku-gnosis.dappnode:3500" },
+        { dnpName: "lodestar-gnosis.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lodestar-gnosis.dappnode:3500" },
+
+        // Holesky Testnet Execution Clients
+        { dnpName: "holesky-geth.dnp.dappnode.eth", expectedUrl: "http://holesky-geth.dappnode:8545" },
+        { dnpName: "holesky-besu.dnp.dappnode.eth", expectedUrl: "http://holesky-besu.dappnode:8545" },
+        { dnpName: "holesky-nethermind.dnp.dappnode.eth", expectedUrl: "http://holesky-nethermind.dappnode:8545" },
+        { dnpName: "holesky-erigon.dnp.dappnode.eth", expectedUrl: "http://holesky-erigon.dappnode:8545" },
+
+        // Holesky Testnet Consensus Clients
+        { dnpName: "prysm-holesky.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.prysm-holesky.dappnode:3500" },
+        { dnpName: "lighthouse-holesky.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lighthouse-holesky.dappnode:3500" },
+        { dnpName: "teku-holesky.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.teku-holesky.dappnode:3500" },
+        { dnpName: "nimbus-holesky.dnp.dappnode.eth", expectedUrl: "http://beacon-validator.nimbus-holesky.dappnode:4500" },
+        { dnpName: "lodestar-holesky.dnp.dappnode.eth", expectedUrl: "http://beacon-chain.lodestar-holesky.dappnode:3500" },
+
+        // Lukso  Execution Clients
+        { dnpName: "lukso-geth.dnp.dappnode.eth", expectedUrl: "http://lukso-geth.dappnode:8545" },
+    ];
+
+    testCases.forEach(({ dnpName, expectedUrl }) => {
+        it(`should return the correct URL for ${dnpName}`, function () {
+            expect(getJsonRpcApiFromDnpName(dnpName)).to.equal(expectedUrl);
+        });
+    });
+
+    // Add a test case for invalid DNP name
+    it('should throw an error for an invalid DNP name', function () {
+        expect(() => getJsonRpcApiFromDnpName("invalid.dnp.name")).to.throw("Invalid DNP name format.");
+    });
+});


### PR DESCRIPTION
Added new method `getJsonRpcApiFromDnpName` and a unit test for it. It returns the JSON RPC api of any staking client given its dnpName. 

This method should replace `getUrlFromDnpName`: https://github.com/dappnode/types/blob/3f999ba1b484ee055acf17c21d3a1f9cca59a5a2/src/utils/stakers.ts#L20